### PR TITLE
[Refactor] PR_template이 적용되지 않는 문제(#4)

### DIFF
--- a/.github/ISSUE_TEMPLATE/Refactor.md
+++ b/.github/ISSUE_TEMPLATE/Refactor.md
@@ -1,5 +1,5 @@
 ---
-name: 🛠 Refactor
+name: 🪛 Refactor
 about: File a Refactor/issue
 title: '[Refactor] <title>'
 labels: Refactor

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+#### Linked Issue
+<!--if it has linked issues, wrtie under the this line-->
+<!--관련된 이슈가 있다면 이슈번호를 남겨주세요-->
+#
+
+
+
+#### Motivation
+<!--왜 이렇게 작성했는지 적어주세요-->
+
+#### Key Change ✨
+<!--주요 변경 사항에 대해서 permalink나 commit hash 값을 간단한 설명과 함께 적어주세요-->
+
+


### PR DESCRIPTION
#### Linked Issue
<!--if it has linked issues, wrtie under the this line-->
<!--관련된 이슈가 있다면 이슈번호를 남겨주세요-->
#4, #3 

#### Motivation
<!--왜 이렇게 작성했는지 적어주세요-->
- [Github docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)를 참고해 PR_TEMPLATE를 추가했는데, 제대로 동작하지 않습니다. 
- 핵심적인 부분은 다음과 같았습니다. 
<img width="693" alt="image" src="https://user-images.githubusercontent.com/63002393/184945987-9105469c-3c1b-4389-80c0-7f848a921df8.png">

위 자료를 보고 아래와 같이 시도했습니다.

<img width="371" alt="image" src="https://user-images.githubusercontent.com/63002393/184946169-89947ddf-daab-4cb0-af94-2566e046b7d1.png">

그러나 결과는 템플릿을 고를 수 있는 쿼리가 나타나지 않습니다. 

<img width="1541" alt="image" src="https://user-images.githubusercontent.com/63002393/184946278-25cb4b6c-56ee-403c-aa2e-1903e0d9cce6.png">

현재로서는 `.github/pull_request_template.md` 로만 가능한 상태 인 것 같습니다. Github쪽의 이렇다 한 입장을 발견하지 못했습니다. 
일단 참고한 자료입니다.
[스택오버플로우](https://stackoverflow.com/questions/52139192/github-pull-requests-template-not-showing)




